### PR TITLE
Themes: Use rounded rect for heads up notification

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/HeadsUpNotificationView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/HeadsUpNotificationView.java
@@ -61,6 +61,8 @@ public class HeadsUpNotificationView extends FrameLayout implements SwipeHelper.
 
     private NotificationData.Entry mHeadsUp;
 
+    private static int sRoundedRectCornerRadius = 0;
+
     public HeadsUpNotificationView(Context context, AttributeSet attrs) {
         this(context, attrs, 0);
     }
@@ -69,6 +71,8 @@ public class HeadsUpNotificationView extends FrameLayout implements SwipeHelper.
         super(context, attrs, defStyle);
         mTouchSensitivityDelay = getResources().getInteger(R.integer.heads_up_sensitivity_delay);
         if (DEBUG) Log.v(TAG, "create() " + mTouchSensitivityDelay);
+        sRoundedRectCornerRadius = context.getResources().getDimensionPixelSize(
+                R.dimen.notification_material_rounded_rect_radius);
     }
 
     public void updateResources() {
@@ -189,9 +193,10 @@ public class HeadsUpNotificationView extends FrameLayout implements SwipeHelper.
             int outlineTop = view.getPaddingTop();
 
             // Apply padding to shadow.
-            outline.setRect(outlineLeft, outlineTop,
+            outline.setRoundRect(outlineLeft, outlineTop,
                     view.getWidth() - outlineLeft - view.getPaddingRight(),
-                    view.getHeight() - outlineTop - view.getPaddingBottom());
+                    view.getHeight() - outlineTop - view.getPaddingBottom(),
+                    sRoundedRectCornerRadius);
         }
     };
 


### PR DESCRIPTION
This uses the same value that is used for rounding the corner
of the notification's shadow.

Change-Id: I62bd26c9a4bd90aa29a66ee07f67065a63721e97